### PR TITLE
Fix plugsurfing connector-post-status is invoked regardless ... charge po…

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/extensions/plugsurfing/repository/impl/ConnectorRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/extensions/plugsurfing/repository/impl/ConnectorRepositoryImpl.java
@@ -75,6 +75,8 @@ public class ConnectorRepositoryImpl implements ConnectorRepositroy {
     public List<Integer> getDiscoveredConnPks(String chargeBoxId) {
         return ctx.selectDistinct(CONNECTOR.CONNECTOR_PK)
                   .from(CONNECTOR)
+                  .join(CHARGE_BOX).on(CHARGE_BOX.CHARGE_BOX_ID.eq(CONNECTOR.CHARGE_BOX_ID))
+                  .join(PS_CHARGEBOX).on(PS_CHARGEBOX.CHARGE_BOX_PK.eq(CHARGE_BOX.CHARGE_BOX_PK))
                   .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
                   .and(CONNECTOR.CONNECTOR_ID.notEqual(0))
                   .fetch()


### PR DESCRIPTION
Fix plugsurfing connector-post-status is invoked regardless charge point is PS enabled or not.

I have noticed that when a charge point which is not PlugSurging enabled connect/disconnect to Steve.
